### PR TITLE
Update modbus.yaml

### DIFF
--- a/enervent-modbus-integration/modbus.yaml
+++ b/enervent-modbus-integration/modbus.yaml
@@ -14,7 +14,6 @@
       address: 47
       slave: 1
       data_type: uint16
-      count: 1
       scale: 0.1
       offset: 0
       precision: 0


### PR DESCRIPTION
Fixes error:

2024-01-30 17:13:49.508 ERROR (MainThread) [homeassistant.config] Invalid config for 'modbus' at modbus.yaml, line 13: Enervent: `count` illegal with `data_type: uint16` 'modbus->0->climates->0', got {'name': 'Enervent', 'address': 47, 'slave': 1, 'data_type': 'uint16', 'count': 1, 'scale': 0.1, 'offset': 0, 'precision': 0, 'max_temp': 30, 'min_temp': 15, 'temp_step': 1, 'scan_interval': 5, 'target_temp_register': 135}, please check the docs at https://www.home-assistant.io/integrations/modbus
2024-01-30 17:13:49.508 ERROR (MainThread) [homeassistant.setup] Setup failed for 'modbus': Invalid config.
